### PR TITLE
Merge current settings with default

### DIFF
--- a/src/settings-manager/settings-manager.ts
+++ b/src/settings-manager/settings-manager.ts
@@ -39,7 +39,7 @@ export class SettingsManager<SettingsSchema extends {} = any> {
       await this.saveSettings();
     }
     else if (currentSettings.status === STATUS.FILE_EXISTS) {
-      this.settings = { ...currentSettings.settings };
+      this.settings = { ...this.default, ...currentSettings.settings };
     }
 
     return this.settings;


### PR DESCRIPTION
When settings file already exists, we don't save the default values, for example if there is a new key